### PR TITLE
Extend globbing

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,3 +5,4 @@ echo "-----> Found a .slugcleanup"
 cd $1
 
 cat .slugcleanup | xargs -I {} bash -O extglob -c 'rm -rf {}'
+rm .slugcleanup

--- a/bin/compile
+++ b/bin/compile
@@ -4,9 +4,4 @@ echo "-----> Found a .slugcleanup"
 
 cd $1
 
-shopt -s extglob
-
-cat .slugcleanup | xargs -I {} bash -c 'rm -rf {}'
-rm .slugcleanup
-
-shopt -u extglob
+cat .slugcleanup | xargs -I {} bash -O extglob -c 'rm -rf {}'

--- a/bin/compile
+++ b/bin/compile
@@ -4,5 +4,9 @@ echo "-----> Found a .slugcleanup"
 
 cd $1
 
+shopt -s extglob
+
 cat .slugcleanup | xargs -I {} bash -c 'rm -rf {}'
 rm .slugcleanup
+
+shopt -u extglob


### PR DESCRIPTION
Activates extending globbing when processing the `.slugcleanup` file.

Our use case is due to Rail’s importmaps and Hotwire. The JavaScript controller folders need to persist in `app/javascript`z In out set-up the `app/javascript` folder is remove right before Heroku slug compilation finishes. Since these Hotwire controller folders are unique in that they are the only ones that need to stick around, an exclude glob is desired. This is not available in the standard globbing options, so an extension is added to allow the option.